### PR TITLE
Copy lib files to Jetty. Fixes #1.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -114,6 +114,10 @@ ruby_block 'Copy ext libs into Jetty' do
 
   action :create
   notifies :restart, "service[jetty]"
+
+  not_if do
+    !Dir.glob(File.join(node['jetty']['home'],'/lib/ext/','log4j-*.jar')).empty?
+  end
 end
 
 template "#{node['jetty']['contexts']}/solr.xml" do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -102,6 +102,20 @@ ruby_block 'Copy Solr war into Jetty webapps folder' do
   end
 end
 
+ruby_block 'Copy ext libs into Jetty' do
+  block do
+    lib_files = Dir.glob(File.join(node['solr']['extracted'],'/example/lib/ext') + '**')
+    ext_dir = File.join(node['jetty']['home'],'/lib/ext')
+    
+    Chef::Log.info "Copying #{lib_files} into #{ext_dir}"
+    FileUtils.cp_r(lib_files, ext_dir)
+    raise "Failed to copy ext lib files" unless !Dir.glob(File.join(ext_dir, 'log4j-*.jar')).empty?
+  end
+
+  action :create
+  notifies :restart, "service[jetty]"
+end
+
 template "#{node['jetty']['contexts']}/solr.xml" do
   owner node['jetty']['user']
   group node['jetty']['group']

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -104,9 +104,9 @@ end
 
 ruby_block 'Copy ext libs into Jetty' do
   block do
-    lib_files = Dir.glob(File.join(node['solr']['extracted'],'/example/lib/ext') + '**')
+    lib_files = Dir.glob(File.join(node['solr']['extracted'],'/example/lib/ext/') + '**')
     ext_dir = File.join(node['jetty']['home'],'/lib/ext')
-    
+
     Chef::Log.info "Copying #{lib_files} into #{ext_dir}"
     FileUtils.cp_r(lib_files, ext_dir)
     raise "Failed to copy ext lib files" unless !Dir.glob(File.join(ext_dir, 'log4j-*.jar')).empty?


### PR DESCRIPTION
Added a block to copy external libs that are no longer included in the .war file from Solr 4.3 onwards.
