### PR TITLE
Only try to copy lib files for Solr >= 4.3

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -116,6 +116,7 @@ ruby_block 'Copy ext libs into Jetty' do
   notifies :restart, "service[jetty]"
 
   not_if do
+    /^4\.[1-2]{1,}\.[0-9]{1,}|^[1-3]/.match(node['solr']['version']) ||
     !Dir.glob(File.join(node['jetty']['home'],'/lib/ext/','log4j-*.jar')).empty?
   end
 end


### PR DESCRIPTION
Tests fail when an attempt is made to copy these files under Solr 3.6.2.
